### PR TITLE
Fix initial authorization request payload

### DIFF
--- a/modules/api.py
+++ b/modules/api.py
@@ -179,7 +179,8 @@ def _PostAccessTokenAutomated(grant_type, code):
         'Content-Type': 'application/x-www-form-urlencoded'}
     if grant_type == 'authorization_code':
         data = {'grant_type': 'authorization_code', 'code': code,
-                'redirect_uri': credentials.callbackUrl}  # gets access and refresh tokens using authorization code
+                'redirect_uri': credentials.callbackUrl, 
+                'client_id': credentials.appKey}  # gets access and refresh tokens using authorization code
     elif grant_type == 'refresh_token':
         data = {'grant_type': 'refresh_token', 'refresh_token': code}  # refreshes the access token
     else:


### PR DESCRIPTION
By adding the client_id as part of the data, I was able to get a access and refresh token. Without it, the API would respond with a 400, saying "Bad Request". I am not sure if the API was recently updated or something. I am using a non-localhost redirect uri if that makes any difference at all. @tylerebowers maybe check this out in your env and see how it does.

Also while I have your attention, it would be nice to note in the readme that tkinter is a required dependency, it didn't come with my Python install :)